### PR TITLE
search by issue weight

### DIFF
--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -319,7 +319,7 @@ class Issues extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'issues/' .$this->encodePath($issue_iid)).'/participants');
     }
-  
+
     /**
      * {@inheritDoc}
      */
@@ -351,6 +351,9 @@ class Issues extends AbstractApi
         $resolver->setDefined('assignee_id')
             ->setAllowedTypes('assignee_id', 'integer')
         ;
+      $resolver->setDefined('weight')
+        ->setAllowedTypes('weight', 'integer')
+      ;
 
         return $resolver;
     }


### PR DESCRIPTION
Supports https://gitlab.com/drupalspoons/drupal-issue-migration/-/merge_requests/4

This is needed so we can search for existing issues by nid ID. Which we previously stored in weight field.